### PR TITLE
Default elasticsearch handler transport uppercase first character.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -412,7 +412,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('id')->end()
                                     ->scalarNode('host')->end()
                                     ->scalarNode('port')->defaultValue(9200)->end()
-                                    ->scalarNode('transport')->defaultValue('http')->end()
+                                    ->scalarNode('transport')->defaultValue('Http')->end()
                                     ->scalarNode('user')->defaultNull()->end()
                                     ->scalarNode('password')->defaultNull()->end()
                                 ->end()


### PR DESCRIPTION
With default elasticksearch handler transport I have exception on linux machine: 'Invalid transport'.
In elastica client liblary default transport value is 'Http' not 'http'.
https://github.com/ruflin/Elastica/blob/master/lib/Elastica/Connection.php#L29
https://github.com/ruflin/Elastica/blob/master/lib/Elastica/Transport/AbstractTransport.php#L92
